### PR TITLE
chore(deps): bump rusqlite from 0.24 to 0.26

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/LawnGnome/bb8-rusqlite"
 [dependencies]
 async-trait = "0.1"
 bb8 = "0.7"
-rusqlite = "0.24"
+rusqlite = "0.26"
 thiserror = "1"
 tokio = { version = "1", features = ["rt", "rt-multi-thread"] }
 

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,7 +1,7 @@
 use std::path::Path;
 
 use bb8_rusqlite::RusqliteConnectionManager;
-use rusqlite::{named_params, NO_PARAMS};
+use rusqlite::named_params;
 use tempfile::NamedTempFile;
 use tokio::task;
 
@@ -15,15 +15,15 @@ async fn example(path: &Path) -> anyhow::Result<()> {
     // available non-blocking threads to do work on. (Of course, in this trivial
     // example, there's no actual need for this.)
     let value = task::block_in_place(move || -> anyhow::Result<i32> {
-        conn.execute("CREATE TABLE t (a INTEGER)", NO_PARAMS)?;
-        conn.execute_named(
+        conn.execute("CREATE TABLE t (a INTEGER)", [])?;
+        conn.execute(
             "INSERT INTO t (a) VALUES (:a)",
             named_params! {
                 ":a": 42,
             },
         )?;
 
-        Ok(conn.query_row("SELECT a FROM t", NO_PARAMS, |row| row.get(0))?)
+        Ok(conn.query_row("SELECT a FROM t", [], |row| row.get(0))?)
     })?;
 
     println!("we stored this value: {}", value);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,8 @@ use async_trait::async_trait;
 use bb8::ManageConnection;
 use rusqlite::{Connection, OpenFlags};
 
+pub use rusqlite;
+
 #[cfg(test)]
 mod tests;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@ use std::{
 
 use async_trait::async_trait;
 use bb8::ManageConnection;
-use rusqlite::{Connection, OpenFlags, NO_PARAMS};
+use rusqlite::{Connection, OpenFlags};
 
 #[cfg(test)]
 mod tests;
@@ -97,7 +97,7 @@ impl ManageConnection for RusqliteConnectionManager {
         let options = self.0.clone();
 
         // Technically, we don't need to use spawn_blocking() here, but doing so
-        // means we won't inadvertantly block this task for any length of time,
+        // means we won't inadvertently block this task for any length of time,
         // since rusqlite is inherently synchronous.
         Ok(tokio::task::spawn_blocking(move || match &options.mode {
             OpenMode::Plain => rusqlite::Connection::open(&options.path),
@@ -116,11 +116,11 @@ impl ManageConnection for RusqliteConnectionManager {
         conn: &mut bb8::PooledConnection<'_, Self>,
     ) -> Result<(), Self::Error> {
         // Matching bb8-postgres, we'll try to run a trivial query here. Using
-        // block_in_place() gives better behaviour if the SQLite call blocks for
+        // block_in_place() gives better behavior if the SQLite call blocks for
         // some reason, but means that we depend on the tokio multi-threaded
         // runtime being active. (We can't use spawn_blocking() here because
         // Connection isn't Sync.)
-        tokio::task::block_in_place(|| conn.execute("SELECT 1", NO_PARAMS))?;
+        tokio::task::block_in_place(|| conn.execute("SELECT 1", []))?;
         Ok(())
     }
 


### PR DESCRIPTION
I'm currently working at [ood_persistence](https://github.com/pleshevskiy/ood_persistence). I would like to see your crate in my dependencies, but I can't do that without these changes. Thank you!